### PR TITLE
fix: escape description when in title of <a>

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/viewNews.jsp
+++ b/src/main/webapp/WEB-INF/jsp/viewNews.jsp
@@ -102,7 +102,7 @@
         <script type="text/template" id="${n}news-story-template">
             {{#each this}}
                 <li>
-                    <a href="{{link}}" title="{{{description}}}" ${ newWindow ? "target=\"_blank\"" : "" }>{{{title}}}</a>
+                    <a href="{{link}}" title="{{description}}" ${ newWindow ? "target=\"_blank\"" : "" }>{{{title}}}</a>
                 </li>
             {{/each}}
         </script>


### PR DESCRIPTION
`{{{text}}}` is raw and should not be used in title attribute of <a>. Changing to `{{text}}` which is escaped.