### PR TITLE
fix: removed refs to log4j and commons-logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,10 @@
                         <groupId>javax.script</groupId>
                         <artifactId>groovy-engine</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -261,19 +265,6 @@
                 <artifactId>ehcache-core</artifactId>
                 <version>${ehcache.version}</version>
             </dependency>
-            <!-- For sl4j/logback logging, see https://wiki.jasig.org/display/PLT/Logging+Best+Practices -->
-            <dependency>
-                <groupId>commons-logging</groupId>
-                <artifactId>commons-logging</artifactId>
-                <version>1.2</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>log4j</groupId>
-                <artifactId>log4j</artifactId>
-                <version>1.2.17</version>
-                <scope>provided</scope>
-            </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
@@ -379,6 +370,12 @@
                 <artifactId>spring-aop</artifactId>
                 <version>${spring.version}</version>
                 <scope>runtime</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
@@ -482,6 +479,12 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/src/main/java/org/jasig/portlet/newsreader/hibernate/ApplicationContextConnectionProvider.java
+++ b/src/main/java/org/jasig/portlet/newsreader/hibernate/ApplicationContextConnectionProvider.java
@@ -25,7 +25,8 @@ import java.util.Properties;
 
 import javax.sql.DataSource;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.hibernate.HibernateException;
 import org.hibernate.connection.ConnectionProvider;
 import org.jasig.portlet.newsreader.spring.PortletApplicationContextLocator;
@@ -45,7 +46,7 @@ public class ApplicationContextConnectionProvider implements ConnectionProvider 
 
     private ApplicationContext context;
 
-    private final Logger logger = Logger.getLogger(getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     @Override
     public void close() throws HibernateException {

--- a/src/main/java/org/jasig/portlet/newsreader/util/SchemaCreator.java
+++ b/src/main/java/org/jasig/portlet/newsreader/util/SchemaCreator.java
@@ -24,7 +24,8 @@ import java.util.List;
 
 import javax.sql.DataSource;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.jasig.portlet.newsreader.spring.PortletApplicationContextLocator;
@@ -52,7 +53,7 @@ public class SchemaCreator implements ApplicationContextAware {
 
     private ApplicationContext applicationContext;
 
-    private final Logger logger = Logger.getLogger(getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     public static void main(String[] args) {
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -29,48 +29,48 @@
 <configuration scan="true" scanPeriod="30 seconds">
   <contextName>NewsReaderPortlet</contextName>
 
-  <!-- 
-   | Propagate log levels to java.util.logging 
+  <!--
+   | Propagate log levels to java.util.logging
    +-->
   <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
     <resetJUL>true</resetJUL>
   </contextListener>
 
-  <!-- 
-   | Expose the logback configuration via JMX 
+  <!--
+   | Expose the logback configuration via JMX
    +-->
   <jmxConfigurator />
 
-  <!-- 
+  <!--
    | Specify a local property that sets up the logging directory
    +-->
-  <property scope="local" name="LOG_DIR" value="${news.webapp.root}/../../logs/${CONTEXT_NAME}" />
+  <property scope="local" name="LOG_DIR" value="${catalina.base}/logs" />
 
   <!--
    | Setup a file based logger that rolls
-   | 
+   |
    | http://logback.qos.ch/manual/appenders.html#RollingFileAppender
    +-->
   <appender name="LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <!-- 
+    <!--
      | Name of the current log file
      +-->
     <File>${LOG_DIR}/${CONTEXT_NAME}.log</File>
-    
-    <!-- 
+
+    <!--
      | Log message pattern configuration
-     | 
+     |
      | http://logback.qos.ch/manual/layouts.html#conversionWord
      +-->
     <encoder>
       <pattern>%-5level [%thread] %logger{36} %d{ISO8601} - %msg%n</pattern>
     </encoder>
-    
+
     <!--
      | Rolls the log file every 24 hours
      | gzip the archived log file
      | Delete archived log files older than 28 days
-     | 
+     |
      | http://logback.qos.ch/manual/appenders.html#TimeBasedRollingPolicy
      +-->
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
@@ -79,14 +79,14 @@
     </rollingPolicy>
   </appender>
 
-  <!-- 
+  <!--
    | Setup default log level to INFO
    +-->
   <root level="INFO">
     <appender-ref ref="LOG" />
   </root>
 
-  <!-- 
+  <!--
    | Turn up logging for portlet specific package
    +-->
   <!--


### PR DESCRIPTION
Replacing refs to log4j and commons-logging to address security issues. Commons-logging does not have any reported issues, but we are focusing on 1 logging approach.